### PR TITLE
Add a bit of context

### DIFF
--- a/about.html
+++ b/about.html
@@ -57,7 +57,7 @@
         To make this clearer, we have tweaked our wording.</p>
 
         <p>The two dates we have used are the dates of the
-        last elections being called:
+        prior elections being called:
         <ul>
             <li>NI: <strong>16th January 2018</strong>, called in Stormont a week
                 after the resignation of the Deputy First Minister

--- a/about.html
+++ b/about.html
@@ -1,0 +1,105 @@
+<html>
+
+<head>
+    <title>Days since Northern Ireland had a government : About</title>
+
+    <!-- Opengraph -->
+    <meta property="og:site_name" content="How long has Northern Ireland not had a government?">
+    <meta property="og:description" content="How long has Northern Ireland not had a government?">
+    <meta property="og:title" content="How long has Northern Ireland not had a government?">
+    <meta property="og:url" content="https://howlonghasnorthernirelandnothadagovernment.com">
+    <meta property="og:type" content="website">
+
+    <link href='https://fonts.googleapis.com/css?family=Oswald' rel='stylesheet' type='text/css'>
+    <style>
+        #main {
+            width: 80%;
+            color: #fff;
+            padding: 10%;
+            font-family: 'Oswald', sans-serif;
+            background-color: #9ca6dd;
+            text-align: left;
+            font-size: 1.25em;
+        }
+
+        .record {
+            font-size: 80%;
+            padding-top: 2em;
+            padding-bottom: 2em;
+        }
+
+        a {
+            color: #4c567d;
+        }
+
+        small {
+            font-size: 50%;
+        }
+    </style>
+
+</head>
+
+<body>
+    <div id="main">
+        <h1>How we counted this</h1>
+
+        <p>It turns out time-since-government is surprisingly subjective and,
+        in particular, our approach does <em>not</em> match Guinness World Record's
+        methodology. That is time for <em>government formation</em>,
+        based on days since the most recent election. Belgium holds the record at 541 days.</p>
+
+        <p>However, NI was without a government for
+        around two months prior to the last election, which had no impact on the stalemate,
+        so we have calculated based
+        on time since official government collapse. It is likely that the same Belgian crisis is
+        also the longest time without an elected government in a developed country during peacetime,
+        but there is no official Guinness World Record.
+        To make this clearer, we have tweaked our wording.</p>
+
+        <p>The two dates we have used are the dates of the
+        last elections being called:
+        <ul>
+            <li>NI: <strong>16th January 2018</strong>, called in Stormont a week
+                after the resignation of the Deputy First Minister
+                <a href="https://www.bbc.co.uk/news/live/uk-northern-ireland-politics-38635708">(more)</a>,</p>
+            <li>Belgium: <strong>26th April 2010</strong>, called by the King on the day
+                of the resignation of the Prime Minister.</p>
+        </ul>
+
+        <p>Belgium did not have an official government again until 6th December 2011, 589 days later.</p>
+
+        <p>Either way, Guinness World Records have confirmed that Northern Ireland is
+        not eligible to receive the record. Nonetheless, NI will still pass Belgium's
+        record in a few weeks, so our ticker will keep counting.</p>
+
+        <p>Thanks to, amongst others,
+        <a href="https://www.bbc.co.uk/news/amp/uk-northern-ireland-politics-45134828?__twitter_impression=true">Guinness World Records &amp; BBC News</a>
+        for clarifying the official position.
+        </p>
+
+        <h1>Events</h1>
+
+        <p>This site is purely informational, without commentary, and is not associated
+        with any specific events or political perspectives.</p>
+
+        <p>However, we realise that people visiting here may looking for this detail,
+        as the lack of government has direct, practical impact on individuals and communities in NI.
+        A number of activities are running around Northern Ireland;
+        some, such as those organised under
+        <a href="https://twitter.com/hashtag/WeDeserveBetter">#WeDeserveBetter</a>
+        <a href="https://twitter.com/hashtag/August28">#August28</a>,
+        actively protesting the current lack of
+        government, and some simply marking the day, as in Belgium seven years ago.</p>
+    </div>
+
+    <!-- Global site tag (gtag.js) - Google Analytics Ask Bolster for numbers-->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-8275151-10"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+        gtag('config', 'UA-8275151-10');
+    </script>
+</body>
+
+</html>

--- a/about.html
+++ b/about.html
@@ -82,7 +82,7 @@
         <p>This site is purely informational, without commentary, and is not associated
         with any specific events or political perspectives.</p>
 
-        <p>However, we realise that people visiting here may looking for this detail,
+        <p>However, we realise that people visiting here may be looking for this detail,
         as the lack of government has direct, practical impact on individuals and communities in NI.
         A number of activities are running around Northern Ireland;
         some, such as those organised under

--- a/about.html
+++ b/about.html
@@ -70,7 +70,7 @@
 
         <p>Either way, Guinness World Records have confirmed that Northern Ireland is
         not eligible to receive the record. Nonetheless, NI will still pass Belgium's
-        record in a few weeks, so our ticker will keep counting.</p>
+        record very shortly, so our ticker will keep counting.</p>
 
         <p>Thanks to, amongst others,
         <a href="https://www.bbc.co.uk/news/amp/uk-northern-ireland-politics-45134828?__twitter_impression=true">Guinness World Records &amp; BBC News</a>

--- a/index.html
+++ b/index.html
@@ -61,11 +61,11 @@
             There are
             <span id="record-container"></span>
             days until
-            <a href='https://en.wikipedia.org/wiki/2010%E2%80%9311_Belgian_government_formation'>the record</a>.
+            <a href='https://en.wikipedia.org/wiki/2010%E2%80%9311_Belgian_government_formation'>passing Belgium</a>.
         </p>
 
         <p>
-            <small>With thanks to https://github.com/hearmecode/days-since</small>
+        <small><a href="about.html">More info</a><br/>With thanks to https://github.com/hearmecode/days-since</small>
         </p>
     </div>
 


### PR DESCRIPTION
This adds an About page and small link from the index page. In particular, the About page contains:

* a section on the date calculation
* acknowledgement of BBC and GWR assessment
* follow-on link to other groups